### PR TITLE
DDCYLS-8570 PPT:Previously entered information should persist when using Change links

### DIFF
--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureAddressController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureAddressController.scala
@@ -50,6 +50,7 @@ class CaptureAddressController @Inject() (mcc: MessagesControllerComponents,
           firstName <- soleTraderIdentificationService
                          .retrieveFullName(journeyId)
                          .map(optFullName => optFullName.map(_.firstName).getOrElse(throw new IllegalStateException("Full name not found")))
+          storedAddress <- soleTraderIdentificationService.retrieveAddress(journeyId)
         } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
@@ -59,7 +60,7 @@ class CaptureAddressController @Inject() (mcc: MessagesControllerComponents,
               journeyId  = journeyId,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureAddressController.submit(journeyId),
-              form       = CaptureAddressForm.apply(),
+              form       = storedAddress.fold(CaptureAddressForm.apply())(CaptureAddressForm.apply().fill),
               countries  = config.getOrderedCountryListByLanguage(request.messages.lang.code)
             )
           )

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureDateOfBirthController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureDateOfBirthController.scala
@@ -50,6 +50,7 @@ class CaptureDateOfBirthController @Inject() (mcc: MessagesControllerComponents,
           firstName <- soleTraderIdentificationService
                          .retrieveFullName(journeyId)
                          .map(optFullName => optFullName.map(_.firstName).getOrElse(throw new IllegalStateException("Full name not found")))
+          storedDateOfBirth <- soleTraderIdentificationService.retrieveDateOfBirth(journeyId)
         } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
@@ -58,7 +59,7 @@ class CaptureDateOfBirthController @Inject() (mcc: MessagesControllerComponents,
               firstName,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureDateOfBirthController.submit(journeyId),
-              form       = captureDateOfBirthForm()
+              form       = storedDateOfBirth.fold(captureDateOfBirthForm())(captureDateOfBirthForm().fill)
             )
           )
         }

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureFullNameController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureFullNameController.scala
@@ -46,7 +46,10 @@ class CaptureFullNameController @Inject() (mcc: MessagesControllerComponents,
   def show(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
     authorised().retrieve(internalId) {
       case Some(authInternalId) =>
-        journeyService.getJourneyConfig(journeyId, authInternalId).map { journeyConfig =>
+        for {
+          journeyConfig  <- journeyService.getJourneyConfig(journeyId, authInternalId)
+          storedFullName <- soleTraderIdentificationService.retrieveFullName(journeyId)
+        } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
 
@@ -54,7 +57,7 @@ class CaptureFullNameController @Inject() (mcc: MessagesControllerComponents,
             view(
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureFullNameController.submit(journeyId),
-              form       = captureFullNameForm.apply(),
+              form       = storedFullName.fold(captureFullNameForm.apply())(captureFullNameForm.apply().fill),
               label      = if (messages.isDefinedAt("optFullNamePageLabel")) messages("optFullNamePageLabel") else messages("full-name.title")
             )
           )

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureNinoController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureNinoController.scala
@@ -52,6 +52,7 @@ class CaptureNinoController @Inject() (mcc: MessagesControllerComponents,
           firstName <- soleTraderIdentificationService
                          .retrieveFullName(journeyId)
                          .map(optFullName => optFullName.map(_.firstName).getOrElse(throw new IllegalStateException("Full name not found")))
+          storedNino <- soleTraderIdentificationService.retrieveNino(journeyId)
         } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
@@ -61,7 +62,7 @@ class CaptureNinoController @Inject() (mcc: MessagesControllerComponents,
               journeyId            = journeyId,
               pageConfig           = journeyConfig.pageConfig,
               formAction           = routes.CaptureNinoController.submit(journeyId),
-              form                 = CaptureNinoForm.form,
+              form                 = storedNino.fold(CaptureNinoForm.form)(CaptureNinoForm.form.fill),
               noNinoJourneyEnabled = isEnabled(EnableNoNinoJourney)
             )
           )

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierController.scala
@@ -45,14 +45,17 @@ class CaptureOverseasTaxIdentifierController @Inject() (mcc: MessagesControllerC
   def show(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
     authorised().retrieve(internalId) {
       case Some(authInternalId) =>
-        journeyService.getJourneyConfig(journeyId, authInternalId).map { journeyConfig =>
+        for {
+          journeyConfig       <- journeyService.getJourneyConfig(journeyId, authInternalId)
+          storedOverseasTaxId <- soleTraderIdentificationService.retrieveOverseasTaxIdentifier(journeyId)
+        } yield {
           implicit val messages: Messages = messagesHelper.getRemoteMessagesApi(journeyConfig).preferred(request)
           Ok(
             view(
               journeyId  = journeyId,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureOverseasTaxIdentifierController.submit(journeyId),
-              form       = CaptureOverseasTaxIdentifierForm.form
+              form       = CaptureOverseasTaxIdentifierForm.form.fill(storedOverseasTaxId)
             )
           )
         }

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierController.scala
@@ -55,7 +55,7 @@ class CaptureOverseasTaxIdentifierController @Inject() (mcc: MessagesControllerC
               journeyId  = journeyId,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureOverseasTaxIdentifierController.submit(journeyId),
-              form       = CaptureOverseasTaxIdentifierForm.form.fill(storedOverseasTaxId)
+              form       = storedOverseasTaxId.fold(CaptureOverseasTaxIdentifierForm.form)(id => CaptureOverseasTaxIdentifierForm.form.fill(Some(id)))
             )
           )
         }

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierCountryController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierCountryController.scala
@@ -44,7 +44,10 @@ class CaptureOverseasTaxIdentifierCountryController @Inject() (mcc: MessagesCont
   def show(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
     authorised().retrieve(internalId) {
       case Some(authInternalId) =>
-        journeyService.getJourneyConfig(journeyId, authInternalId).map { journeyConfig =>
+        for {
+          journeyConfig <- journeyService.getJourneyConfig(journeyId, authInternalId)
+          storedCountry <- soleTraderIdentificationService.retrieveOverseasTaxIdentifierCountry(journeyId)
+        } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
           Ok(
@@ -52,7 +55,7 @@ class CaptureOverseasTaxIdentifierCountryController @Inject() (mcc: MessagesCont
               journeyId  = journeyId,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureOverseasTaxIdentifierCountryController.submit(journeyId),
-              form       = CaptureOverseasTaxIdentifierCountryForm.form,
+              form       = storedCountry.fold(CaptureOverseasTaxIdentifierCountryForm.form)(CaptureOverseasTaxIdentifierCountryForm.form.fill),
               countries  = config.getOrderedCountryListByLanguage(request.messages.lang.code)
             )
           )

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureSaPostcodeController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureSaPostcodeController.scala
@@ -47,7 +47,10 @@ class CaptureSaPostcodeController @Inject() (mcc: MessagesControllerComponents,
   def show(journeyId: String): Action[AnyContent] = Action.async { implicit request =>
     authorised().retrieve(internalId) {
       case Some(authInternalId) =>
-        journeyService.getJourneyConfig(journeyId, authInternalId).map { journeyConfig =>
+        for {
+          journeyConfig    <- journeyService.getJourneyConfig(journeyId, authInternalId)
+          storedSaPostcode <- soleTraderIdentificationService.retrieveSaPostcode(journeyId)
+        } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
           Ok(
@@ -55,7 +58,7 @@ class CaptureSaPostcodeController @Inject() (mcc: MessagesControllerComponents,
               journeyId  = journeyId,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureSaPostcodeController.submit(journeyId),
-              form       = CaptureSaPostcodeForm.form
+              form       = storedSaPostcode.fold(CaptureSaPostcodeForm.form)(CaptureSaPostcodeForm.form.fill)
             )
           )
         }

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureSautrController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureSautrController.scala
@@ -50,6 +50,7 @@ class CaptureSautrController @Inject() (mcc: MessagesControllerComponents,
           firstName <- soleTraderIdentificationService
                          .retrieveFullName(journeyId)
                          .map(optFullName => optFullName.map(_.firstName).getOrElse(throw new IllegalStateException("Full name not found")))
+          storedSautr <- soleTraderIdentificationService.retrieveSautr(journeyId)
         } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
@@ -59,7 +60,7 @@ class CaptureSautrController @Inject() (mcc: MessagesControllerComponents,
               journeyId  = journeyId,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureSautrController.submit(journeyId),
-              form       = CaptureSautrForm.form
+              form       = storedSautr.fold(CaptureSautrForm.form)(CaptureSautrForm.form.fill)
             )
           )
         }

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureSautrNewController.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureSautrNewController.scala
@@ -50,6 +50,7 @@ class CaptureSautrNewController @Inject() (mcc: MessagesControllerComponents,
           firstName <- soleTraderIdentificationService
                          .retrieveFullName(journeyId)
                          .map(optFullName => optFullName.map(_.firstName).getOrElse(throw new IllegalStateException("Full name not found")))
+          storedSautr <- soleTraderIdentificationService.retrieveSautr(journeyId)
         } yield {
           val remoteMessagesApi = messagesHelper.getRemoteMessagesApi(journeyConfig)
           implicit val messages: Messages = remoteMessagesApi.preferred(request)
@@ -59,7 +60,7 @@ class CaptureSautrNewController @Inject() (mcc: MessagesControllerComponents,
               journeyId  = journeyId,
               pageConfig = journeyConfig.pageConfig,
               formAction = routes.CaptureSautrNewController.submit(journeyId),
-              form       = CaptureSautrNewForm.form
+              form       = CaptureSautrNewForm.form.fill(storedSautr)
             )
           )
         }

--- a/app/uk/gov/hmrc/soletraderidentificationfrontend/forms/CaptureSautrNewForm.scala
+++ b/app/uk/gov/hmrc/soletraderidentificationfrontend/forms/CaptureSautrNewForm.scala
@@ -52,7 +52,7 @@ object CaptureSautrNewForm {
         case None    => option_no
       }
 
-      Map(key -> stringValue)
+      Map(key -> stringValue) ++ value.map(sautrValueKey -> _)
     }
   }
 

--- a/it/test/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/soletraderidentificationfrontend/controllers/CaptureOverseasTaxIdentifierControllerISpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.soletraderidentificationfrontend.controllers
 
 import play.api.libs.ws.WSResponse
-import play.api.test.Helpers.{BAD_REQUEST, NO_CONTENT, OK, SEE_OTHER, await, defaultAwaitTimeout}
+import play.api.test.Helpers.{BAD_REQUEST, NOT_FOUND, NO_CONTENT, OK, SEE_OTHER, await, defaultAwaitTimeout}
 import uk.gov.hmrc.soletraderidentificationfrontend.assets.TestConstants._
 import uk.gov.hmrc.soletraderidentificationfrontend.stubs.{AuthStub, SoleTraderIdentificationStub}
 import uk.gov.hmrc.soletraderidentificationfrontend.utils.ComponentSpecHelper
@@ -42,6 +42,7 @@ class CaptureOverseasTaxIdentifierControllerISpec
           )
         )
         stubAuth(OK, successfulAuthResponse())
+        stubRetrieveOverseasTaxIdentifier(testJourneyId)(NOT_FOUND)
         get(s"/identify-your-sole-trader-business/$testJourneyId/overseas-identifier")
       }
 

--- a/test/controllers/CaptureStoredAnswersControllerSpec.scala
+++ b/test/controllers/CaptureStoredAnswersControllerSpec.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import helpers.TestConstants._
+import org.jsoup.Jsoup
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import services.mocks.{MockJourneyService, MockSoleTraderIdentificationService}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.soletraderidentificationfrontend.controllers._
+import uk.gov.hmrc.soletraderidentificationfrontend.models.{JourneyConfig, PageConfig}
+
+import scala.concurrent.Future
+
+class CaptureStoredAnswersControllerSpec
+    extends AnyWordSpec
+    with Matchers
+    with MockitoSugar
+    with BeforeAndAfterEach
+    with MockJourneyService
+    with MockSoleTraderIdentificationService {
+
+  private val mockAuthConnector: AuthConnector = mock[AuthConnector]
+
+  private val pageConfig = PageConfig(
+    optServiceName        = Some(testServiceName),
+    deskProServiceId      = "test-service-id",
+    signOutUrl            = testSignOutUrl,
+    enableSautrCheck      = true,
+    accessibilityUrl      = testAccessibilityUrl,
+    optFullNamePageLabel  = None,
+    labels                = None
+  )
+
+  private val journeyConfig = JourneyConfig(
+    continueUrl               = testContinueUrl,
+    businessVerificationCheck = false,
+    pageConfig                = pageConfig,
+    regime                    = testRegime
+  )
+
+  private lazy val app: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        "metrics.enabled" -> false,
+        "metrics.jvm" -> false,
+        "microservice.metrics.graphite.enabled" -> false
+      )
+      .overrides(
+        bind[AuthConnector].toInstance(mockAuthConnector),
+        bind[uk.gov.hmrc.soletraderidentificationfrontend.services.JourneyService].toInstance(mockJourneyService),
+        bind[uk.gov.hmrc.soletraderidentificationfrontend.services.SoleTraderIdentificationService].toInstance(mockSoleTraderIdentificationService)
+      )
+      .build()
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockAuthConnector)
+    when(
+      mockAuthConnector.authorise[Option[String]](any(), any[Retrieval[Option[String]]]())(any(), any())
+    ).thenReturn(Future.successful(Some(testInternalId)))
+  }
+
+  private def documentOf(result: Future[play.api.mvc.Result]) =
+    Jsoup.parse(contentAsString(result))
+
+  "CaptureFullNameController.show" should {
+    "pre-populate the stored full name" in {
+      mockGetJourneyConfig(testJourneyId, testInternalId)(Future.successful(journeyConfig))
+      mockRetrieveFullName(testJourneyId)(Future.successful(Some(testFullName)))
+
+      val controller = app.injector.instanceOf[CaptureFullNameController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("first-name").`val`() mustBe testFirstName
+      doc.getElementById("last-name").`val`() mustBe testLastName
+    }
+  }
+
+  "CaptureDateOfBirthController.show" should {
+    "pre-populate the stored date of birth" in {
+      mockGetJourneyConfig(testJourneyId, testInternalId)(Future.successful(journeyConfig))
+      mockRetrieveFullName(testJourneyId)(Future.successful(Some(testFullName)))
+      mockRetrieveDateOfBirth(testJourneyId)(Future.successful(Some(testDateOfBirth)))
+
+      val controller = app.injector.instanceOf[CaptureDateOfBirthController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("date-of-birth-day").`val`() mustBe testDateOfBirth.getDayOfMonth.toString
+      doc.getElementById("date-of-birth-month").`val`() mustBe testDateOfBirth.getMonth.toString
+      doc.getElementById("date-of-birth-year").`val`() mustBe testDateOfBirth.getYear.toString
+    }
+  }
+
+  "CaptureNinoController.show" should {
+    "pre-populate the stored nino" in {
+      mockGetJourneyConfig(testJourneyId, testInternalId)(Future.successful(journeyConfig))
+      mockRetrieveFullName(testJourneyId)(Future.successful(Some(testFullName)))
+      mockRetrieveNino(testJourneyId)(Future.successful(Some(testNino)))
+
+      val controller = app.injector.instanceOf[CaptureNinoController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("nino").`val`() mustBe testNino
+    }
+  }
+
+  "CaptureAddressController.show" should {
+    "pre-populate the stored address" in {
+      mockGetJourneyConfig(testJourneyId, testInternalId)(Future.successful(journeyConfig))
+      mockRetrieveFullName(testJourneyId)(Future.successful(Some(testFullName)))
+      mockRetrieveAddress(testJourneyId)(Future.successful(Some(testAddress)))
+
+      val controller = app.injector.instanceOf[CaptureAddressController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("address1").`val`() mustBe testAddress.line1
+      doc.getElementById("address2").`val`() mustBe testAddress.line2
+      doc.getElementById("postcode").`val`() mustBe testAddress.postcode.get
+      doc.select("option[selected]").eachAttr("value") must contain(testAddress.countryCode)
+    }
+  }
+
+  "CaptureSautrNewController.show" should {
+    "pre-populate the stored sautr selection and value" in {
+      mockGetJourneyConfig(testJourneyId, testInternalId)(Future.successful(journeyConfig))
+      mockRetrieveFullName(testJourneyId)(Future.successful(Some(testFullName)))
+      mockRetrieveSautr(testJourneyId)(Future.successful(Some(testSautr)))
+
+      val controller = app.injector.instanceOf[CaptureSautrNewController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("optSautr").hasAttr("checked") mustBe true
+      doc.getElementById("sa-utr").`val`() mustBe testSautr
+    }
+  }
+}

--- a/test/controllers/CaptureStoredAnswersControllerSpec.scala
+++ b/test/controllers/CaptureStoredAnswersControllerSpec.scala
@@ -48,13 +48,13 @@ class CaptureStoredAnswersControllerSpec
   private val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
   private val pageConfig = PageConfig(
-    optServiceName        = Some(testServiceName),
-    deskProServiceId      = "test-service-id",
-    signOutUrl            = testSignOutUrl,
-    enableSautrCheck      = true,
-    accessibilityUrl      = testAccessibilityUrl,
-    optFullNamePageLabel  = None,
-    labels                = None
+    optServiceName       = Some(testServiceName),
+    deskProServiceId     = "test-service-id",
+    signOutUrl           = testSignOutUrl,
+    enableSautrCheck     = true,
+    accessibilityUrl     = testAccessibilityUrl,
+    optFullNamePageLabel = None,
+    labels               = None
   )
 
   private val journeyConfig = JourneyConfig(
@@ -67,8 +67,8 @@ class CaptureStoredAnswersControllerSpec
   private lazy val app: Application =
     new GuiceApplicationBuilder()
       .configure(
-        "metrics.enabled" -> false,
-        "metrics.jvm" -> false,
+        "metrics.enabled"                       -> false,
+        "metrics.jvm"                           -> false,
         "microservice.metrics.graphite.enabled" -> false
       )
       .overrides(


### PR DESCRIPTION
Changes - 

Retain sole trader journey answers when navigating from check your answers

- amended CaptureAddressController.scala
- amended CaptureDateOfBirthController.scala
- amended CaptureFullNameController.scala
- amended CaptureNinoController.scala
- amended CaptureOverseasTaxIdentifierController.scala amended CaptureOverseasTaxIdentifierCountryController.scala amended CaptureSaPostcodeController.scala
- amended CaptureSautrController.scala
- amended CaptureSautrNewController.scala
- amended CaptureSautrNewForm.scala
- amended CaptureStoredAnswersControllerSpec.scala

Related PR's - 

- https://github.com/hmrc/plastic-packaging-tax-registration-frontend/pull/651
- https://github.com/hmrc/incorporated-entity-identification-frontend/pull/244
- https://github.com/hmrc/partnership-identification-frontend/pull/116